### PR TITLE
Add debug mode to handle errors in tasks

### DIFF
--- a/src/dataflowtask.jl
+++ b/src/dataflowtask.jl
@@ -27,7 +27,7 @@ mutable struct DataFlowTask
         tj    = new(data,mode,TASKCOUNTER[],priority,label)
         addnode!(sch,tj,true)
         deps  = inneighbors(sch.dag,tj) |> copy
-        tj.task = @task begin
+        tj.task = @task handle_errors() do
             for ti in deps
                 wait(ti)
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,3 +11,35 @@ function Base.iterate(rt::Iterators.Reverse{<:OrderedDict}, i)
     i < 1 && return nothing
     return (Pair(t.keys[i], t.vals[i]), i-1)
 end
+
+
+
+"""
+    enable_debug(mode = true)
+
+If `mode` is true (the default), enable debug mode: errors inside tasks will be
+shown.
+"""
+function enable_debug(mode = true)
+    @eval debug_mode() = $mode
+end
+
+debug_mode() = true
+
+function handle_errors(body)
+    if debug_mode()
+        try
+            body()
+        catch e
+            e == :stop && return
+            showerror(stderr, e)
+            println(stderr, "\nStacktrace:")
+            foreach(stacktrace(catch_backtrace())) do s
+                println("  ", s)
+            end
+            rethrow()
+        end
+    else
+        body()
+    end
+end


### PR DESCRIPTION
By default, debug mode is enabled: errors inside tasks are displayed to
stderr as they occur. Debug mode can be enabled/disabled via

     DataFlowTasks.enable_debug(mode = true)