### PR TITLE
Test TiledFactorization in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,14 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - run: git clone https://github.com/maltezfaria/TiledFactorization
+      - run: |
+          julia --project="TiledFactorization" -e '
+            import Pkg
+            Pkg.develop(Pkg.PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            Pkg.test(coverage=true)
+          '
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
With this PR, the CI workflow integrates new steps during which [https://github.com/maltezfaria/TiledFactorization](TileFactorization) is cloned and its automated tests are passed. One advantage of integrating this as new steps in the existing workflow is that code coverage statistics should account for the code paths activated by TiledFactorization.

FWIW, an alternate way of doing things would have been to define a new, dedicated job (alongside the "Julia" test matrix and the "Documentation" job). This could make it easier to see whether failures come from internal tests or TiledFactorization, but it would not easily allow code coverage statistics to include TiledFactorization tests.