### PR TITLE
add a `ReentrantLock` to the `DAG` structure

### DIFF
--- a/src/arrayinterface.jl
+++ b/src/arrayinterface.jl
@@ -10,15 +10,12 @@ using LinearAlgebra
     memory_overlap(di::SubArray,dj::Array)
     memory_overlap(di::Array,dj::SubArray)
 
-When both `di` and `dj` are of type `Array`, compare their addresses. If one is
+When both `di` and `dj` are `Array`s of bitstype, compare their addresses. If one is
 of type `SubArray`, compare the parent.
 """
-memory_overlap(di::Array,dj::Array) = pointer(di)===pointer(dj)
+memory_overlap(di::Array,dj::Array)    = pointer(di)===pointer(dj)
 memory_overlap(di::SubArray,dj::Array) = memory_overlap(di.parent,dj)
 memory_overlap(di::Array,dj::SubArray) = memory_overlap(dj.parent,di)
-
-memory_overlap(di::SubArray,dj::LinearAlgebra.AbstractTriangular) = memory_overlap(parent(dj),di)
-memory_overlap(di::LinearAlgebra.AbstractTriangular,dj::SubArray) = memory_overlap(dj,di)
 
 """
     memory_overlap(di::SubArray,dj::SubArray)

--- a/src/dag.jl
+++ b/src/dag.jl
@@ -13,6 +13,7 @@ struct DAG{T}
     inoutlist::OrderedDict{T,Tuple{Set{T},Set{T}}}
     cond_push::Condition
     cond_empty::Condition
+    lock::ReentrantLock
     sz_max::Ref{Int}
     _buffer::Set{Int} # used to keep track of visited nodes when needed
 end
@@ -30,8 +31,9 @@ function DAG{T}(sz = typemax(Int)) where T
     inoutlist  = OrderedDict{T,Tuple{Set{T},Set{T}}}()
     cond_push  = Condition()
     cond_empty = Condition()
+    lock = ReentrantLock()
     _buffer    = Set{Int}()
-    return DAG{T}(inoutlist,cond_push,cond_empty,Ref(sz),_buffer)
+    return DAG{T}(inoutlist,cond_push,cond_empty,lock,Ref(sz),_buffer)
 end
 
 function Base.resize!(dag::DAG,sz)
@@ -51,6 +53,9 @@ const TaskGraph = DAG{DataFlowTask}
 
 Base.isempty(dag::DAG)     = isempty(dag.inoutlist)
 Base.getindex(dag::DAG,i)  = dag.inoutlist[i]
+
+Base.lock(dag::DAG)   = lock(dag.lock)
+Base.unlock(dag::DAG) = unlock(dag.lock)
 
 """
     num_nodes(dag::DAG)
@@ -124,16 +129,19 @@ function addnode!(dag::DAG,kv::Pair,check=false)
     while num_nodes(dag) == dag.sz_max[]
         wait(dag.cond_push)
     end
+    lock(dag)
+    try
+        t₀ = time_ns()
+        push!(dag.inoutlist,kv)
+        k,v = kv
+        check  && update_edges!(dag,k)
+        t₁ = time_ns()
 
-    t₀ = time_ns()
-    push!(dag.inoutlist,kv)
-    k,v = kv
-    check  && update_edges!(dag,k)
-    t₁ = time_ns()
-
-    tid = Threads.threadid()
-    _log_mode() && push!(getlogger().insertionlogs[tid], InsertionLog(t₀, t₁, tag(k), tid))
-
+        tid = Threads.threadid()
+        _log_mode() && push!(getlogger().insertionlogs[tid], InsertionLog(t₀, t₁, tag(k), tid))
+    finally
+        unlock(dag)
+    end
     return dag
 end
 
@@ -212,18 +220,23 @@ has_edge(dag::DAG,i,j) = j ∈ outneighbors(dag,i)
 Remove node `i` and all of its edges from `dag`.
 """
 function remove_node!(dag::DAG,i)
-    if !isempty(inneighbors(dag,i))
-        @warn "removing a node with incoming neighbors"
+    lock(dag)
+    try
+        if !isempty(inneighbors(dag,i))
+            @warn "removing a node with incoming neighbors"
+        end
+        (inlist,outlist) = pop!(dag.inoutlist,i)
+        # remove i from the inlist of all its outneighbors
+        for j in outlist
+            pop!(inneighbors(dag,j),i)
+        end
+        # notify a task waiting to push into the dag
+        notify(dag.cond_push,nothing;all=false)
+        # if dag is empty, notify
+        isempty(dag) && notify(dag.cond_empty)
+    finally
+        unlock(dag)
     end
-    (inlist,outlist) = pop!(dag.inoutlist,i)
-    # remove i from the inlist of all its outneighbors
-    for j in outlist
-        pop!(inneighbors(dag,j),i)
-    end
-    # notify a task waiting to push into the dag
-    notify(dag.cond_push,nothing;all=false)
-    # if dag is empty, notify
-    isempty(dag) && notify(dag.cond_empty)
     return
 end
 

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -97,11 +97,6 @@ const LOGGER = Ref{Logger}()
 # ----------------------- PLOTTING ----------------------
 # -------------------------------------------------------
 
-"""
-    plot(logger::Logger;categories)
-
-Plot recipe to visualize the logged events in `logger`.
-"""
 @recipe function f(logger::Logger;categories=String[])
     if isempty(Iterators.flatten(logger.tasklogs))
         error("logger is empty: nothing to plot")
@@ -197,7 +192,7 @@ Plot recipe to visualize the logged events in `logger`.
             color --> :red
             count == 0 ? label --> "task insertion" : label --> nothing
             count += 1
-        
+
             # Vertices of log square
             # -----------------------
             x1 = (insertionlog.time_start  * 10^(-9)  - firsttime)
@@ -209,7 +204,7 @@ Plot recipe to visualize the logged events in `logger`.
             # --------------------
             othertime -= x2-x1
             insertingtime += x2-x1
-        
+
             # Returns
             [x1,x2,x2,x1,x1],[y1,y1,y2,y2,y1]
         end
@@ -279,7 +274,7 @@ end
 
 
 ############################################################################
-#                           Dag Plotting                                  
+#                           Dag Plotting
 ############################################################################
 
 """
@@ -291,7 +286,7 @@ and to be plotted by GraphViz with Graph(logger_to_dot())
 """
 function logger_to_dot(logger=getlogger())
     path = criticalpath()
-    
+
     # Write DOT graph
     # ---------------
     str = "strict digraph dag {rankdir=LR;layout=dot;"
@@ -314,7 +309,7 @@ end
 
 
 """
-    criticalpath() --> path  
+    criticalpath() --> path
 Finds the critical path of the logger's DAG
 """
 function criticalpath()
@@ -322,7 +317,7 @@ function criticalpath()
     # Note : we add a virtual first node 1 that represent the beginning of the DAG
     nb_nodes = sum(length(threadlog) for threadlog ∈ getlogger().tasklogs)
     adj = NaN * ones(nb_nodes+1, nb_nodes+1)
-    
+
     # Find Critical Path
     # ------------------
     for tasklog ∈ Iterators.flatten(getlogger().tasklogs)


### PR DESCRIPTION
Adds a lock to the `DAG` so that adding and removing a node can acquire the lock and avoid the execution of another task which tries to do either.