### PR TITLE
Allow access mode tags in macro parameters + more macro tests

### DIFF
--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -233,6 +233,33 @@ infer task dependencies.
 
 ## Examples:
 
+Below are 3 equivalent ways to create the same `DataFlowTask`, which expresses a
+Read-Write dependency on `C` and Read dependencies on `A` and `B`
+
+```
+using LinearAlgebra
+A = rand(10, 10)
+B = rand(10, 10)
+C = rand(10, 10)
+α, β = (100.0, 10.0)
+
+# Option 1: annotate arguments in a function call
+@dspawn mul!(@RW(C), @R(A), @R(B), α, β)
+
+# Option 2: specify data access modes in the code block
+@dspawn begin
+   @RW C
+   @R  A B
+   mul!(C, A, B, α, β)
+end
+
+# Option 3: specify data access modes after the code block
+# (i.e. alongside keyword arguments)
+@dspawn mul!(C, A, B, α, β) @RW(C) @R(A,B)
+```
+
+Here is a more complete example, demonstrating a full computation involving 2 different tasks.
+
 ```jldoctest
 using DataFlowTasks
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
I had an idea regarding the "awkwardness" of call like

```julia
@task begin
   @RW x
   @R  y
   fun(x, adjoint(y))
end
```

With this PR, it is possible to specify access modes after the task body, much like the old API worked:

```julia
@task fun(@RW(x), adjoint(y)) @R(y)
```

This means that the list of optional arguments to the macro can now be a mix of parameters specifications (like `priority` & `label`) and access mode specs. In other words, the `@dspawn` macro can now be invoked in even more ways than before, so I felt like more tests were in order. This PR also tries to check the correctness of macro expansion more extensively, by testing all ways to specify data access modes and task parameters.

If you like it, I can document the new syntax. And if we merge it in the main branch, we can use this syntax in `TiledFactorization`.