### PR TITLE
Optional dependencies management

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ThreadPools = "b189fb0b-2eb5-4ed4-bc0c-d34c51242431"

--- a/optional-deps/Project.toml
+++ b/optional-deps/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
+GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"


### PR DESCRIPTION
This is a proposal for a tool allowing to conveniently load optional dependencies.

For example:
```julia
using DataFlowTasks
DataFlowTasks.@using_opt GLMakie
```

It currently works by temporarily activating a project located in `DataFlowTasks/optional-deps/Project.toml`, loading the requested dependencies, and finally re-activating the previous project. An other option could have been to fiddle with `LOAD_PATH`; not sure which idea is the cleanest...