### PR TITLE
Don't change logging/debug/sequential mode unnecessarily

### DIFF
--- a/src/dataflowtask.jl
+++ b/src/dataflowtask.jl
@@ -167,13 +167,16 @@ By default, sequential mode is disabled when the program starts.
 function force_sequential(seq::Bool = true; static::Bool = false)
     dyn = static ? :sta : :dyn
     par = seq    ? :seq : :par
+    _sequential_mode() == (dyn, par) && return (dyn, par)
+
     if static
         @warn "Statically setting sequential/parallel mode is not recommended"
     end
     @eval _sequential_mode() = $(tuple(dyn, par))
-    nothing
+    return (dyn, par)
 end
-force_sequential(false)
+
+_sequential_mode() = (:dyn, :par)
 
 
 function _dtask(continuation, expr::Expr, kwargs; source=LineNumberNode(@__LINE__, @__FILE__))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,7 +13,7 @@ function Base.iterate(rt::Iterators.Reverse{<:OrderedDict}, i)
 end
 
 """
-    enable_log(mode = false)
+    enable_log(mode = true)
 
 If `mode=true`, information regarding the [`DataFlowTask`](@ref)s will be logged
 in the current logger.
@@ -21,6 +21,7 @@ in the current logger.
 ## See also: [`getlogger`](@ref), [`setlogger!`](@ref), [`TaskLog`](@ref).
 """
 function enable_log(mode = true)
+    _log_mode() == mode && return mode
     @eval _log_mode() = $mode
     mode
 end
@@ -34,7 +35,9 @@ If `mode` is `true` (the default), enable debug mode: errors inside tasks will b
 shown.
 """
 function enable_debug(mode = true)
+    _debug_mode() == mode && return mode
     @eval _debug_mode() = $mode
+    return mode
 end
 
 _debug_mode() = true


### PR DESCRIPTION
When `enable_log()`, `enable_debug()` or `force_sequential()` is called, only
really change the internal state of `DataFlowTasks` if this corresponds to a real
mode change. This is to avoid unnecessary invalidation of user code relying on
`DataFlowTasks` (see #27).