### PR TITLE
Logging should wait for task graph to be empty

### DIFF
--- a/src/dataflowtask.jl
+++ b/src/dataflowtask.jl
@@ -34,11 +34,6 @@ mutable struct DataFlowTask
         tj = new(data, mode, TASKCOUNTER[], priority, label)
         addnode!(sch, tj, true)
 
-        # Store inneighbors if logging activated
-        _log_mode() &&
-            haslogger() &&
-            (inneighbors_ = [task.tag for task in inneighbors(sch.dag, tj)])
-
         deps = inneighbors(sch.dag, tj) |> copy
         tj.task = @task handle_errors() do
             for ti in deps
@@ -51,7 +46,7 @@ mutable struct DataFlowTask
             # Push new TaskLog if logging activated
             if _log_mode() && haslogger()
                 tid = Threads.threadid()
-                task_log = TaskLog(tj.tag, t₀, t₁, tid, inneighbors_, tj.label)
+                task_log = TaskLog(tj.tag, t₀, t₁, tid, [t.tag for t in deps], tj.label)
                 push!(_getloginfo().tasklogs[tid], task_log)
             end
             put!(sch.finished, tj)

--- a/src/dataflowtask.jl
+++ b/src/dataflowtask.jl
@@ -48,6 +48,9 @@ mutable struct DataFlowTask
                 tid = Threads.threadid()
                 task_log = TaskLog(tj.tag, t₀, t₁, tid, [t.tag for t in deps], tj.label)
                 push!(_getloginfo().tasklogs[tid], task_log)
+                if Threads.threadid() != tid
+                    @warn "Thread migration occurred while inserting a TaskLog"
+                end
             end
             put!(sch.finished, tj)
             return res

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -121,12 +121,14 @@ function with_logging!(f, l::LogInfo)
     # taskgraph must be empty before starting, or we may log dependencies on
     # tasks that are not in the logger
     tg = get_active_taskgraph()
-    _wait = !isempty(tg)
-    msg = """logging requires an empty taskgraph to start. Waiting for pending
-    tasks to be completed...
-    """
-    _wait && (@warn msg; wait(tg))
-    _wait && (@warn "done waiting.")
+    if !isempty(tg)
+        msg = """logging requires an empty taskgraph to start. Waiting for
+        pending tasks to be completed...
+        """
+        @warn msg
+        wait(tg)
+        @warn "done."
+    end
     # check if logger is already active, switch to new logger, record, and
     # switch back
     _log_mode() == true ||

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -67,6 +67,7 @@ end
 
 #TODO: show more relevant information
 function Base.show(io::IO, l::LogInfo)
+    nbtasknodes(l) == 0 && return print(io, "empty LogInfo")
     nodes = topological_sort(l)
     n = length(nodes)
     cp = longest_path(l)
@@ -117,6 +118,17 @@ end
 Similar to [`with_logging`](@ref), but append events to `l`.
 """
 function with_logging!(f, l::LogInfo)
+    # taskgraph must be empty before starting, or we may log dependencies on
+    # tasks that are not in the logger
+    tg = get_active_taskgraph()
+    _wait = !isempty(tg)
+    msg = """logging requires an empty taskgraph to start. Waiting for pending
+    tasks to be completed...
+    """
+    _wait && (@warn msg; wait(tg))
+    _wait && (@warn "done waiting.")
+    # check if logger is already active, switch to new logger, record, and
+    # switch back
     _log_mode() == true ||
         error("you must run `enable_log()` to activate the logger before profiling")
     old_logger = _getloginfo()
@@ -164,8 +176,9 @@ end
 """
     DataFlowTasks.@log expr --> LogInfo
 
-Execute `expr` and return a [`LogInfo`](@ref) instance with the recorded
-events.
+Execute `expr` and return a [`LogInfo`](@ref) instance with the recorded events.
+The `Logger` waits for the current taskgraph (see [`get_active_taskgraph`](@ref)
+to be empty before starting.
 
 !!! warning
     The returned `LogInfo` instance may be incomplete if `block` returns before all

--- a/src/taskgraph.jl
+++ b/src/taskgraph.jl
@@ -81,6 +81,8 @@ function Base.wait(taskgraph::TaskGraph)
     return taskgraph
 end
 
+Base.isempty(taskgraph::TaskGraph) = isempty(taskgraph.dag)
+
 capcity(taskgraph) = taskgraph |> dag |> capacity
 
 """


### PR DESCRIPTION
- Fixes #60 by making sure the `TaskGraph` is empty before logging starts
- Adds a sanity check to address concerns with task migration during logging process (#59)