### PR TITLE
Simpler `describe(loginfo, categories)` API

### DIFF
--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -55,7 +55,6 @@ profiling the compilation time, it is often advisable to perform a "dry run" of
 the code first, as done in the example below:
 
 ```@example profiling
-
 # Context
 A = ones(2000, 2000)
 B = ones(3000, 3000)
@@ -69,14 +68,12 @@ log_info = DataFlowTasks.@log work(A, B)
 
 The `log_info` object above, of [`LogInfo`](@ref DataFlowTasks.LogInfo) type,
 contains information that can be used to reconstruct both the inferred task
-dependencies, and the parallel execution traces of the `DataFlowTask`s. This
-information can be extracted by creating a [`ExtendedLogInfo`](@ref
-DataFlowTasks.ExtendedLogInfo) object using the [`extractloggerinfo`](@ref
-DataFlowTasks.extractloggerinfo) function, as illustrated next:
+dependencies, and the parallel execution traces of the `DataFlowTask`s. A
+summary of this information can be displayed using [`DataFlowTasks.describe`](@ref), as
+illustrated next:
 
 ```@example profiling
-extloginfo, _ = DataFlowTasks.extractloggerinfo(log_info; categories=["init", "mutate", "read"])
-extloginfo
+DataFlowTasks.describe(log_info; categories=["init", "mutate", "read"])
 ```
 
 More powerful visualization capabilities, such as displaying the underlying

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -208,17 +208,17 @@ weight(t::TaskLog) = task_duration(t) * 1e-9
 #= Contains data to plot the Gantt Chart (parallel trace).
 It's a Struct of Array paradigm where all the entries i
 of all the arrays tells us information about a same task. =#
-"""
-    struct Gantt
+# """
+#     struct Gantt
 
-Structured used ton produce a [`Gantt
-chart`](https://en.wikipedia.org/wiki/Gantt_chart) of the parallel traces of the
-tasks recorded in a [`LogInfo`](@ref) instance. This structure is used when
-plotting the parallel trace with `Makie.plot`.
+# Structured used ton produce a [`Gantt
+# chart`](https://en.wikipedia.org/wiki/Gantt_chart) of the parallel traces of the
+# tasks recorded in a [`LogInfo`](@ref) instance. This structure is used when
+# plotting the parallel trace with `Makie.plot`.
 
-See [`extractloggerinfo`](@ref) for more information on how to create an `Gantt`
-instance.
-"""
+# See [`extractloggerinfo`](@ref) for more information on how to create an `Gantt`
+# instance.
+# """
 struct Gantt
     threads::Vector{Int64}      # Thread on wich the task ran
     jobids::Vector{Int64}       # Task type
@@ -235,15 +235,15 @@ struct Gantt
 end
 
 #= Contains additional post-processed informations on the LogInfo =#
-"""
-    struct ExtendedLogInfo
+# """
+#     struct ExtendedLogInfo
 
-Appends informations to [`LogInfo`](@ref) to make it easier to visualize and
-exctract useful information.
+# Appends informations to [`LogInfo`](@ref) to make it easier to visualize and
+# exctract useful information.
 
-See [`extractloggerinfo`](@ref) for more information on how to create an
-`ExtendedLogInfo` instance.
-"""
+# See [`extractloggerinfo`](@ref) for more information on how to create an
+# `ExtendedLogInfo` instance.
+# """
 mutable struct ExtendedLogInfo
     firsttime::Float64              # First measured time
     lasttime::Float64               # Last measured time
@@ -278,9 +278,21 @@ mutable struct ExtendedLogInfo
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", extloginfo::ExtendedLogInfo)
-    println(io, "ExtendedLogInfo")
-    get(io, :compact, false) && return
+"""
+    describe(loginfo::LogInfo; categories = String[])
+    describe(io, loginfo::LogInfo; categories = String[])
+
+Analyses the information contained in `loginfo` and displays a summary on `io` (`stdout` by default).
+
+Passing a `categories` argument allows grouping tasks by category. The
+`categories` can be a vector of `String`s or a vector of `String => Regex`
+pairs, which will be matched against the tasks' labels.
+"""
+describe(loginfo::LogInfo; categories = String[]) =
+    describe(stdout, loginfo; categories = categories)
+
+function describe(io::IO, loginfo::LogInfo; categories = String[])
+    extloginfo, _ = extractloggerinfo(loginfo; categories = categories)
 
     # format the output below using printf style. Right align so that all
     # numbers are aligned
@@ -319,16 +331,6 @@ function jobid(label::String, categories)
     return length(categories) + 1
 end
 
-"""
-    extractloggerinfo(loginfo::LogInfo; categories = String[]) -->
-    ExtendedLogInfo, Gantt
-
-Analyses the information contained in `loginfo` and returns an
-[`ExtendedLogInfo`](@ref) instance and a [`Gantt`](@ref) instance. Passing a
-`categories` argument allows to group tasks by category. The `categories` can be
-a vector of `String`s or a vector of `String => Regex` pairs, which will be
-matched against the tasks' labels.
-"""
 function extractloggerinfo(loginfo::LogInfo; categories = String[])
     extloginfo = ExtendedLogInfo(loginfo, categories, longest_path(loginfo))
     gantt = Gantt()


### PR DESCRIPTION
Following the changes in #62, I wanted to suggest an IMO simpler API to show detailed information about a `LogInfo` object. Instead of exposing `ExtendedLogInfo` and `extractloggerinfo` (which by side-effect also pulls in `Gantt`), I thought we could simply provide a function that extracts all the info under the hood and simply displays it.

I suggest using a function named `describe` for that (which is heavily inspired by [`StatsBase`](https://juliastats.org/StatsBase.jl/stable/scalarstats/#DataAPI.describe)), along the lines of:
```julia-repl
julia> log_info = DataFlowTasks.@log work(A, B)
julia> DataFlowTasks.describe(log_info; categories=["init", "mutate", "read"])
• Elapsed time           : 0.036
  ├─ Critical path       : 0.036
  ╰─ No-wait             : 0.006

• Run time               : 0.288
  ├─ Computing           :   0.051
  │  ├─ init             :     0.013
  │  ├─ mutate           :     0.034
  │  ├─ read             :     0.004
  │  ╰─ unlabeled        :     0.000
  ├─ Task insertion      :   0.000
  ╰─ Other (waiting)     :   0.237
```

Of course, all this comes from the assumption that `ExtendedLogInfo` instances aren't otherwise useful to the user. But maybe I'm wrong here?

If you like this idea, I can go ahead and update existing examples so that they also demonstrate the use of this new API.

[Documentation preview](https://maltezfaria.github.io/DataFlowTasks.jl/previews/PR64/profiling/)