### PR TITLE
Update examples to use the `describe(log_info)` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,19 @@ dag = GraphViz.Graph(log_info)
 
 ![](https://maltezfaria.github.io/DataFlowTasks.jl/dev/readme/cholesky_dag.svg)
 
-The parallel trace plot shows a timeline of the tasks' execution on available
-threads. It helps in understanding how tasks were scheduled. The same window also
-carries other general information allowing to better understand the
-performance limiting factors:
+The `LogInfo` object also contains all the data needed to profile the parallel
+application. A summary of the profiling information can be displayed in the
+REPL using the `DataFlowTasks.describe` function:
+
+````julia
+DataFlowTasks.describe(log_info; categories=["chol", "ldiv", "schur"])
+````
+
+but it is often more convenient to see this information in a graphical
+way. The parallel trace plot shows a timeline of the tasks execution on
+available threads. It helps in understanding how tasks were scheduled. The
+same window also carries other general information allowing to better
+understand the performance limiting factors:
 
 ````julia
 using CairoMakie # or GLMakie in order to have more interactivity

--- a/docs/src/examples/blur-roberts/blur-roberts.jl
+++ b/docs/src/examples/blur-roberts/blur-roberts.jl
@@ -158,8 +158,7 @@ function blur_roberts_tiled!(img, ts; width, tmp=similar(img))
 end
 
 # Decomposing the original image in tiles of size $512\times 512$, the tiled
-# application of the filters yields the same result as above, in a more
-# cache-efficient way:
+# application of the filters yields the same result as above:
 
 ts = 512
 
@@ -168,7 +167,9 @@ blur_roberts_tiled!(mat1, ts; width, tmp)
 
 mat2img(PixelType, mat1)
 
-#-
+# Depending on the system, the fact that memory is now accessed in blocks may
+# (or may not) have a significant impact on the performance, due to cache
+# effects.
 
 t_tiled = @belapsed blur_roberts_tiled!(x, ts; width=$width, tmp=$tmp) setup=(x=copy(mat)) evals=1
 
@@ -251,9 +252,9 @@ barplot([t_seq, t_tiled, t_dft],
 # We can gain more insight by collecting profiling data:
 
 GC.gc()
-
 mat1 .= mat;
 log_info = DataFlowTasks.@log wait(blur_roberts_dft!(mat1, ts; width, tmp))
+DataFlowTasks.describe(log_info)
 
 # The parallel trace shows how blur and roberts tasks are interspersed in the time line:
 

--- a/docs/src/examples/cholesky/cholesky.jl
+++ b/docs/src/examples/cholesky/cholesky.jl
@@ -184,19 +184,23 @@ dag = GraphViz.Graph(log_info)
 
 #-
 
-# The parallel trace plot gives us more details about the
-# performance limiting factors:
+# We can also readily get more details about the performance limiting factors:
+
+DataFlowTasks.describe(log_info; categories=["chol", "ldiv", "schur"])
+
+# and, at the price of loading `Makie`, display these in a more convenient
+# profile plot:
 
 using CairoMakie # or GLMakie in order to have more interactivity
 trace = plot(log_info; categories=["chol", "ldiv", "schur"])
 
 # The overhead incurred by `DataFlowTasks` seems relatively small here: the time
 # taken inserting tasks is barely measurable, and the scheduling did not lead to
-# threads waiting idly for too long. This is confirmed by the "Time Bounds"
-# plot, showing a measured wall clock time not too much longer than the lower
-# bound obtained when suppressing idle time.
+# threads waiting idly for too long. This is confirmed by the bottom middle plot,
+# showing a measured wall clock time not too much longer than the lower bound
+# obtained when suppressing idle time.
 #
-# The "Times per Category" plot seems to indicate that the matrix
+# The computing time breakdown by category seems to indicate that the matrix
 # multiplications performed in the "Schur" tasks account for the majority of the
 # computing time. Trying to optimize these would be a priority to increase the
 # sequential performance of the factorization.

--- a/docs/src/examples/cholesky/cholesky.jl
+++ b/docs/src/examples/cholesky/cholesky.jl
@@ -200,7 +200,7 @@ trace = plot(log_info; categories=["chol", "ldiv", "schur"])
 # showing a measured wall clock time not too much longer than the lower bound
 # obtained when suppressing idle time.
 #
-# The computing time breakdown by category seems to indicate that the matrix
+# The "Computing time: breakdown by category" plot seems to indicate that the matrix
 # multiplications performed in the "Schur" tasks account for the majority of the
 # computing time. Trying to optimize these would be a priority to increase the
 # sequential performance of the factorization.

--- a/docs/src/examples/lcs/lcs.jl
+++ b/docs/src/examples/lcs/lcs.jl
@@ -296,9 +296,12 @@ barplot(
 
 (; nthreads = Threads.nthreads(), speedup  = t_seq / t_par)
 
-# Let's try and understand why. The run-time data collected above can help build
-# a profiling plot, which gives some insight about the performances of our
-# parallel version:
+# Let's try and understand why. The run-time data collected above contains useful information
+
+DFT.describe(log_info; categories = ["init", "tile", "backtrack"])
+
+# which we can also visualize in a profiling plot. This gives some insight about
+# the performances of our parallel version:
 
 plot(log_info; categories = ["init", "tile", "backtrack"])
 

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -79,7 +79,8 @@ DataFlowTasks.describe(log_info; categories=["init", "mutate", "read"])
 More powerful visualization capabilities, such as displaying the underlying
 `DAG` or showing the parallel trace of the tasks executed, are available upon
 loading additional packages such as `GraphViz` or `Makie`. These are discussed
-in the following sections.
+in the following sections, where we also explain in more detail the meaning of
+the numbers output by [`DataFlowTasks.describe`](@ref).
 
 !!! warning
     When using `@log`, you typically want the block of code being benchmarked
@@ -165,38 +166,39 @@ Also note that inserting tasks into the graph involves memory allocations, and
 may thus trigger garbage collector sweeps. When this happens, the time spent in
 the garbage collector is also shown in the plot.
 
-### Activity plot
+### Run time: breakdown by activity
 
-The "activity" barplot (in the bottom left corner of the window) gives us
-information on the break-down of parallel computing times (summed over all threads):
+A barplot in the bottom left corner of the window gives us information on the
+break-down of parallel run times (summed over all threads):
 
 * `Computing` represents the total time spent in the tasks bodies (i.e. "useful"
   work);
-* `Inserting` represents the total time spent inserting nodes in the DAG
+* `Task Insertion` represents the total time spent inserting nodes in the DAG
   (i.e. overhead induced by `DataFlowTasks`), possibly including any time spent
   in the GC if it is triggered by a memory allocation in the task insertion process;
-* `Other` represents the total idle time on all threads (which may be due to bad
+* `Other (idle)` represents the total idle time on all threads (which may be due to bad
   scheduling, or simply arise by lack of enough exposed parallelism in the
   algorithm).
 
-### Time Bounds plot
+### Elapsed time & bounds
 
-The "Time Bounds" barplot (in the bottom center of the window) tries to present
-insightful information about the performance limiting factors in the computation:
+A barplot in the bottom center of the window tries to present insightful
+information about the elapsed (wall-clock) time of the computation, and its
+limiting factors:
 
-- `critical path` represents the time spent in the longest sequential path in
+- `Elapsed` represents the measured "wall clock time" of the computation; it
+  should be larger than both of the bounds described below;
+
+- `Critical Path` represents the time spent in the longest sequential path in
   the DAG (shown in red in the DAG visualization). As said above, it bounds the
   performance in that even infinitely many threads would still have to compute
   this path sequentially;
   
-- `without waiting` represents the duration of a hypothetical computation in
+- `No-Wait` represents the duration of a hypothetical computation in
   which all computing time would be evenly distributed among threads (i.e. no
   thread would ever have to wait). This also bounds the total time because it
   does not account for dependencies between tasks.
-  
-- `Real` represents the measured "wall clock time" of the computation; it should
-  be larger than both of the aforementioned bounds.
-  
+
 When looking for faster response times, this graph may suggest sensible ways to
 explore. If the measured time is close to the critical path duration, then
 adding more threads will be of no help, but decomposing the work in smaller
@@ -204,11 +206,11 @@ tasks may be useful. On the other hand, if the measured time is close to the
 "without waiting" bound, then adding more workers may reduce the wall clock time
 and scale relatively well.
 
-### Times per Category plot
+### Computing time: breakdown by category
 
-The "Times per Category" barplot (in the bottom right of the window) displays
-the total time spent on all threads while performing user-defined tasks (grouped
-by category as explained above).
+A barplot in the bottom right of the window displays a break-down of the total
+computing time (*i.e.* the total time spent on all threads while performing
+user-defined tasks), grouped by user-provided category as explained above.
 
 When trying to optimize the sequential performance of the algorithm, this is
 where one can get data about what actually takes time (and therefore could

--- a/docs/src/readme/README.jl
+++ b/docs/src/readme/README.jl
@@ -264,10 +264,17 @@ DataFlowTasks.savedag("cholesky_dag.svg", dag) #src
 
 #md # ![](cholesky_dag.svg)
 
-# The parallel trace plot shows a timeline of the tasks' execution on available
-# threads. It helps in understanding how tasks were scheduled. The same window also
-# carries other general information allowing to better understand the
-# performance limiting factors:
+# The `LogInfo` object also contains all the data needed to profile the parallel
+# application. A summary of the profiling information can be displayed in the
+# REPL using the `DataFlowTasks.describe` function:
+
+DataFlowTasks.describe(log_info; categories=["chol", "ldiv", "schur"])
+
+# but it is often more convenient to see this information in a graphical
+# way. The parallel trace plot shows a timeline of the tasks execution on
+# available threads. It helps in understanding how tasks were scheduled. The
+# same window also carries other general information allowing to better
+# understand the performance limiting factors:
 
 using CairoMakie # or GLMakie in order to have more interactivity
 trace = plot(log_info; categories=["chol", "ldiv", "schur"])

--- a/ext/DataFlowTasks_Makie_Ext.jl
+++ b/ext/DataFlowTasks_Makie_Ext.jl
@@ -79,7 +79,7 @@ end
 function activityplot(ax, loginfo::ExtendedLogInfo)
     # Axis attributes
     # ---------------
-    ax.xticks = (1:3, ["Computing", "Inserting", "Other"])
+    ax.xticks = (1:3, ["Computing", "Task\nInsertion", "Other\n(idle)"])
     ax.ylabel = "Time (s)"
 
     # Barplot
@@ -96,7 +96,7 @@ end
 function boundsplot(ax, loginfo::ExtendedLogInfo)
     # Axis attributes
     # ---------------
-    ax.xticks = (1:3, ["Critical\nPath", "Without\nWaiting", "Real"])
+    ax.xticks = (1:3, ["Critical\nPath", "No-Wait", "Elapsed"])
     ax.ylabel = "Time (s)"
 
     # Barplot
@@ -195,9 +195,9 @@ function Makie.plot(loginfo::LogInfo; categories = String[])
     # Layouts
     # --------------------------------------------
     axtrc = Axis(fig[1, 1]; title = "Parallel Trace\n Task Label")
-    axact = Axis(fig[2, 1][1, 1]; title = "Activity")
-    axinf = Axis(fig[2, 1][1, 2]; title = "Time Bounds")
-    axcat = Axis(fig[2, 1][1, 3]; title = "Times per Category")
+    axact = Axis(fig[2, 1][1, 1]; title = "Run time: breakdown by activity")
+    axinf = Axis(fig[2, 1][1, 2]; title = "Elapsed time & bounds")
+    axcat = Axis(fig[2, 1][1, 3]; title = "Computing time: breakdown by category")
     # -------
     rowsize!(fig.layout, 1, Relative(2 / 3))
 

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -298,8 +298,8 @@ function describe(io::IO, loginfo::LogInfo; categories = String[])
     # numbers are aligned
     elapsed = extloginfo.lasttime - extloginfo.firsttime
     @printf(io, "• Elapsed time %-10s: %.3f\n", "", elapsed)
-    @printf(io, "  ├─ %-20s: %.3f\n", "Critical path", extloginfo.t∞)
-    @printf(io, "  ╰─ %-20s: %.3f\n", "No-wait", extloginfo.t_nowait)
+    @printf(io, "  ├─ %-20s: %.3f\n", "Critical Path", extloginfo.t∞)
+    @printf(io, "  ╰─ %-20s: %.3f\n", "No-Wait", extloginfo.t_nowait)
     @printf(io, "\n")
 
     runtime = extloginfo.computingtime + extloginfo.insertingtime + extloginfo.othertime
@@ -310,8 +310,8 @@ function describe(io::IO, loginfo::LogInfo; categories = String[])
         @printf(io, "  │  ├─ %-17s:     %.3f\n", title, extloginfo.timespercat[i])
     end
     @printf(io, "  │  ╰─ %-17s:     %.3f\n", "unlabeled", extloginfo.timespercat[end])
-    @printf(io, "  ├─ %-20s:   %.3f\n", "Task insertion", extloginfo.insertingtime)
-    @printf(io, "  ╰─ %-20s:   %.3f", "Other (waiting)", extloginfo.othertime)
+    @printf(io, "  ├─ %-20s:   %.3f\n", "Task Insertion", extloginfo.insertingtime)
+    @printf(io, "  ╰─ %-20s:   %.3f\n", "Other (idle)", extloginfo.othertime)
 end
 
 #= Gives minimum and maximum times the logger has measured. =#


### PR DESCRIPTION
Following #64, this PR does two relatively minor changes:

1. it updates `Makie.plot(log_info)` and `DFT.describe(log_info)` so that they show the same numbers under the same name; this makes it more easy to document only `Makie.plot` and refer to that when introducing `DFT.describe`.
2. it updates all examples and the README so that they use the new `DFT.describe` API