### PR TITLE
Implicitly add a "data dependency" between each `DataFlowTask` and its underlying `Task`

### DIFF
--- a/src/dag.jl
+++ b/src/dag.jl
@@ -179,7 +179,6 @@ and outgoing edges are updated.
 function update_edges!(dag::DAG, nodej)
     transitively_connected = dag._buffer
     empty!(transitively_connected)
-    hastask = any(x -> isa(x, Task), data(nodej))
     # update dependencies from newer to older and reinfornce transitivity by
     # skipping predecessors of nodes which are already connected
     for (nodei, _) in Iterators.reverse(dag)
@@ -192,13 +191,7 @@ function update_edges!(dag::DAG, nodej)
         (ti ∈ transitively_connected) && continue
         # tasks are handled differently when they appear in the data in that
         # they are checked directly agains the nodej.task field
-        dep = false
-        if hastask
-            for d in data(nodej)
-                d === nodei.task && (dep = true; break)
-            end
-        end
-        dep || data_dependency(nodei, nodej) || continue
+        data_dependency(nodei, nodej) || continue
         addedge!(dag, nodei, nodej)
         update_transitively_connected!(transitively_connected, nodei, dag)
     end

--- a/test/dataflowtask_test.jl
+++ b/test/dataflowtask_test.jl
@@ -21,16 +21,16 @@ import DataFlowTasks as DFT
 
     @testset "access tags in arguments list" begin
         t = DFT.@dtask f(@R(x), @W(y), @RW(z))
-        @test t.data === (x, y, z)
-        @test t.access_mode == (DFT.READ, DFT.WRITE, DFT.READWRITE)
+        @test t.data === (x, y, z, t.task)
+        @test t.access_mode == (DFT.READ, DFT.WRITE, DFT.READWRITE, DFT.READWRITE)
         @test t.priority == 0
         @test t.label == ""
     end
 
     @testset "arrow access tags" begin
         t = DFT.@dtask f(@←(x), @→(y), @↔(z))
-        @test t.data === (x, y, z)
-        @test t.access_mode == (DFT.READ, DFT.WRITE, DFT.READWRITE)
+        @test t.data === (x, y, z, t.task)
+        @test t.access_mode == (DFT.READ, DFT.WRITE, DFT.READWRITE, DFT.READWRITE)
     end
 
     @testset "access tags in task body" begin
@@ -39,21 +39,21 @@ import DataFlowTasks as DFT
             @R y z
             f(x', y', z')
         end
-        @test t.data === (x, y, z)
-        @test t.access_mode == (DFT.WRITE, DFT.READ, DFT.READ)
+        @test t.data === (x, y, z, t.task)
+        @test t.access_mode == (DFT.WRITE, DFT.READ, DFT.READ, DFT.READWRITE)
     end
 
     @testset "access tags in parameters" begin
         t = DFT.@dtask f(x', y', z') @R(x) @W(y) @RW(z)
-        @test t.data === (x, y, z)
-        @test t.access_mode == (DFT.READ, DFT.WRITE, DFT.READWRITE)
+        @test t.data === (x, y, z, t.task)
+        @test t.access_mode == (DFT.READ, DFT.WRITE, DFT.READWRITE, DFT.READWRITE)
     end
 
     @testset "optional parameters" begin
         j = 2
         t = DFT.@dtask f(@W(x), y') @R(y) priority = j label = "task($j)"
-        @test t.data === (x, y)
-        @test t.access_mode == (DFT.WRITE, DFT.READ)
+        @test t.data === (x, y, t.task)
+        @test t.access_mode == (DFT.WRITE, DFT.READ, DFT.READWRITE)
         @test t.priority == 2
         @test t.label == "task(2)"
     end


### PR DESCRIPTION
This is another way of handling #79, in which implicit "data dependencies" are registered between each `DataFlowTask` and its underlying `Task`. It's then possible to handle such dependencies with the regular, `memory_overlap`-based mechanism.

I feel like this is essentially equivalent to the current implementation, but perhaps a bit more straightforward in terms of implementation. @maltezfaria what do you think?

Preview doc: https://maltezfaria.github.io/DataFlowTasks.jl/previews/PR81/

